### PR TITLE
로그아웃 API 추가

### DIFF
--- a/app-api/src/docs/asciidoc/users-api-guide.adoc
+++ b/app-api/src/docs/asciidoc/users-api-guide.adoc
@@ -18,11 +18,18 @@ include::{docdir}/common.adoc[]
 [[title]]
 = SDR API 문서 - 유저 API
 
-[[login]]
+[[카카오_로그인]]
 == 카카오 로그인
-include::{snippets}/users/oauth/kakao/login/http-request.adoc[]
+include::{snippets}/users/kakao/login/http-request.adoc[]
 === Request
-include::{snippets}/users/oauth/kakao/login/request-fields.adoc[]
+include::{snippets}/users/kakao/login/request-fields.adoc[]
 === Response
-include::{snippets}/users/oauth/kakao/login/response-fields.adoc[]
-include::{snippets}/users/oauth/kakao/login/response-body.adoc[]
+include::{snippets}/users/kakao/login/response-fields.adoc[]
+include::{snippets}/users/kakao/login/response-body.adoc[]
+
+[[로그아웃]]
+== 로그아웃
+include::{snippets}/users/logout/http-request.adoc[]
+=== Response
+include::{snippets}/users/logout/response-fields.adoc[]
+include::{snippets}/users/logout/response-body.adoc[]

--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/oauth/OauthKakaoServiceImpl.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/oauth/OauthKakaoServiceImpl.java
@@ -81,21 +81,14 @@ public class OauthKakaoServiceImpl implements OauthKakaoService {
             MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
             HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(requestBody, httpHeaders);
 
-            OauthInfo.KakaoLogoutResponse response = restTemplate.postForObject(
+            restTemplate.postForObject(
                 url,
                 request,
                 OauthInfo.KakaoLogoutResponse.class
             );
 
-            if (response == null) throw new OauthException(702, ErrorMessage.OAUTH_RESPONSE_EMPTY.replace("{oauth}", "Kakao"));
+        } catch (Exception ignored) {
 
-            log.info("response : {}", response);
-        } catch (HttpClientErrorException e) {
-            e.printStackTrace();
-            throw new OauthException(701, ErrorMessage.OAUTH_REQUEST_FAILED.replace("{oauth}", "Kakao"));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new OauthException(700, ErrorMessage.OAUTH_REQUEST_FAILED.replace("{oauth}", "Kakao"));
         }
     }
 

--- a/app-api/src/main/java/com/ddd/chulsi/presentation/users/UsersController.java
+++ b/app-api/src/main/java/com/ddd/chulsi/presentation/users/UsersController.java
@@ -1,13 +1,13 @@
 package com.ddd.chulsi.presentation.users;
 
 import com.ddd.chulsi.application.users.UsersFacade;
+import com.ddd.chulsi.infrastructure.annotation.AuthToken;
 import com.ddd.chulsi.infrastructure.oauth.OauthCommand;
 import com.ddd.chulsi.presentation.shared.response.dto.BaseResponse;
 import com.ddd.chulsi.presentation.users.dto.UsersDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,9 +23,7 @@ public class UsersController {
         return code;
     }
 
-    // TODO : Users 엔티티 연결 후 내부에서 사용할 JWT 및 Users 정보 Response 로 교체 필요
-    //        임시방편으로 현재 Kakao AccessToken 그대로 Return
-    @PostMapping(value = "/oauth/kakao/login", name = "카카오 로그인")
+    @PostMapping(value = "/kakao/login", name = "카카오 로그인")
     public BaseResponse<UsersDTO.LoginResponse> kakaoLogin(
         @RequestBody @Valid UsersDTO.OauthLoginRequest loginRequest,
         HttpServletResponse response
@@ -34,12 +32,11 @@ public class UsersController {
         return BaseResponse.ofSuccess(usersFacade.kakaoLogin(loginCommand, response));
     }
 
-    // TODO : Users Logout 처리 기능 개발 시 이거 사용할 것
-    @PutMapping(value = "/oauth/kakao/logout", name = "카카오 로그아웃")
-    public BaseResponse<Void> kakaoLogout(
-        @RequestHeader(name = HttpHeaders.AUTHORIZATION) String token
+    @PutMapping(value = "/logout", name = "로그아웃")
+    public BaseResponse<Void> logout(
+        @AuthToken String token
     ) {
-        usersFacade.kakaoLogout(token);
+        usersFacade.logout(token);
         return BaseResponse.ofSuccess();
     }
 

--- a/app-api/src/test/java/com/ddd/chulsi/presentation/oauth/UsersControllerTest.java
+++ b/app-api/src/test/java/com/ddd/chulsi/presentation/oauth/UsersControllerTest.java
@@ -1,29 +1,32 @@
 package com.ddd.chulsi.presentation.oauth;
 
 import com.ddd.chulsi.application.users.UsersFacade;
+import com.ddd.chulsi.infrastructure.jwt.JwtTokenUtil;
 import com.ddd.chulsi.infrastructure.oauth.OauthCommand;
 import com.ddd.chulsi.presentation.shared.ControllerTest;
 import com.ddd.chulsi.presentation.users.UsersController;
 import com.ddd.chulsi.presentation.users.dto.UsersDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
-
 
 import static com.ddd.chulsi.infrastructure.inMemory.users.UsersFactory.givenLoginResponse;
 import static com.ddd.chulsi.infrastructure.util.ApiDocumentUtils.getDocumentRequest;
 import static com.ddd.chulsi.infrastructure.util.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -39,15 +42,14 @@ class UsersControllerTest extends ControllerTest {
     private UsersFacade usersFacade;
 
     @Test
-    @DisplayName("카카오 로그인")
-    void kakaoLogin() throws Exception {
+    void 카카오_로그인() throws Exception {
 
         given(usersFacade.kakaoLogin(any(OauthCommand.LoginCommand.class), any(HttpServletResponse.class))).willReturn(givenLoginResponse());
 
         UsersDTO.OauthLoginRequest request = new UsersDTO.OauthLoginRequest("authorizationCode");
 
         mockMvc.perform(
-                post("/users/oauth/kakao/login")
+                post("/users/kakao/login")
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -55,7 +57,7 @@ class UsersControllerTest extends ControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("code").value(200))
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andDo(document("users/oauth/kakao/login",
+            .andDo(document("users/kakao/login",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestFields(
@@ -69,6 +71,32 @@ class UsersControllerTest extends ControllerTest {
                     fieldWithPath("data.usersInfoLogin.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
                     fieldWithPath("data.usersInfoLogin.accessToken").type(JsonFieldType.STRING).description("access token"),
                     fieldWithPath("data.usersInfoLogin.lastLoginAt").type(JsonFieldType.STRING).description("마지막 로그인 일시")
+                )
+            ));
+
+    }
+
+    @Test
+    void 로그아웃() throws Exception {
+
+        doNothing().when(usersFacade).logout(anyString());
+
+        mockMvc.perform(
+                put("/users/logout")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, JwtTokenUtil.PREFIX + "AccessToken")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andDo(document("users/logout",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("결과 데이터")
                 )
             ));
 

--- a/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenJpaRepository.java
+++ b/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenJpaRepository.java
@@ -1,8 +1,13 @@
 package com.ddd.chulsi.domainCore.model.oauthToken;
 
+import com.ddd.chulsi.domainCore.model.shared.DefinedCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OauthTokenJpaRepository extends JpaRepository<OauthToken, UUID> {
+
+    Optional<OauthToken> findByOauthTypeAndOauthId(DefinedCode oauthType, Long oauthId);
+
 }

--- a/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenReader.java
+++ b/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenReader.java
@@ -2,11 +2,7 @@ package com.ddd.chulsi.domainCore.model.oauthToken;
 
 import com.ddd.chulsi.domainCore.model.shared.DefinedCode;
 
-public interface OauthTokenService {
-
-    void save(OauthToken oauthToken);
-
-    void delete(OauthToken oauthToken);
+public interface OauthTokenReader {
 
     OauthToken findByOauthTypeAndOauthId(DefinedCode oauthType, Long oauthId);
 

--- a/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenReaderImpl.java
+++ b/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenReaderImpl.java
@@ -1,0 +1,18 @@
+package com.ddd.chulsi.domainCore.model.oauthToken;
+
+import com.ddd.chulsi.domainCore.model.shared.DefinedCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OauthTokenReaderImpl implements OauthTokenReader {
+
+    private final OauthTokenJpaRepository oauthTokenJpaRepository;
+
+    @Override
+    public OauthToken findByOauthTypeAndOauthId(DefinedCode oauthType, Long oauthId) {
+        return oauthTokenJpaRepository.findByOauthTypeAndOauthId(oauthType, oauthId).orElse(null);
+    }
+
+}

--- a/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenServiceImpl.java
+++ b/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/oauthToken/OauthTokenServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ddd.chulsi.domainCore.model.oauthToken;
 
+import com.ddd.chulsi.domainCore.model.shared.DefinedCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class OauthTokenServiceImpl implements OauthTokenService {
 
+    private final OauthTokenReader oauthTokenReader;
     private final OauthTokenStore oauthTokenStore;
 
     @Override
@@ -17,5 +19,10 @@ public class OauthTokenServiceImpl implements OauthTokenService {
     @Override
     public void delete(OauthToken oauthToken) {
         oauthTokenStore.delete(oauthToken);
+    }
+
+    @Override
+    public OauthToken findByOauthTypeAndOauthId(DefinedCode oauthType, Long oauthId) {
+        return oauthTokenReader.findByOauthTypeAndOauthId(oauthType, oauthId);
     }
 }


### PR DESCRIPTION
- 로그인 RequestMapping 수정
- 로그아웃 통합 및 유저 oauth 정보 있을 경우 oauth 로그아웃 추가 처리
- 카카오 로그아웃 처리 시 오류 무시