### PR TITLE
비밀번호 재설정, 링크 유효성 검사 API 추가

### DIFF
--- a/app-api/src/docs/asciidoc/users-api-guide.adoc
+++ b/app-api/src/docs/asciidoc/users-api-guide.adoc
@@ -67,3 +67,21 @@ include::{snippets}/users/password-find/request-fields.adoc[]
 === Response
 include::{snippets}/users/password-find/response-fields.adoc[]
 include::{snippets}/users/password-find/response-body.adoc[]
+
+[[비밀번호_링크_유효성_검사]]
+== 비밀번호 링크 유효성 검사
+include::{snippets}/users/password-link-alive/http-request.adoc[]
+=== Request
+include::{snippets}/users/password-link-alive/request-fields.adoc[]
+=== Response
+include::{snippets}/users/password-link-alive/response-fields.adoc[]
+include::{snippets}/users/password-link-alive/response-body.adoc[]
+
+[[비밀번호_재설정]]
+== 비밀번호 재설정
+include::{snippets}/users/password-reset/http-request.adoc[]
+=== Request
+include::{snippets}/users/password-reset/request-fields.adoc[]
+=== Response
+include::{snippets}/users/password-reset/response-fields.adoc[]
+include::{snippets}/users/password-reset/response-body.adoc[]

--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/exception/message/ErrorMessage.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/exception/message/ErrorMessage.java
@@ -45,4 +45,8 @@ public class ErrorMessage {
     public static final String OAUTH_REQUEST_FAILED = "{oauth} Oauth 요청에 실패했습니다.";
 
     public static final String EMAIL_SEND_FAILED = "이메일 발송에 실패했습니다.";
+
+    public static final String PASSWORD_VALIDATION_FAILED = "비밀번호는 8자 이상, 20자 이하, 영문, 숫자, 특수문자만 입력 가능합니다";
+
+    public static final String EMAIL_VALIDATION_FAILED = "올바른 이메일 주소를 입력해주세요";
 }

--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/mail/MailService.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/mail/MailService.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface MailService {
 
-    boolean sendMail(List<Users> receiveList);
+    boolean sendMail(List<Users> receiveList, String redisCode);
 
 }

--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/mail/MailServiceImpl.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/mail/MailServiceImpl.java
@@ -20,12 +20,13 @@ public class MailServiceImpl implements MailService {
     private final JavaMailSender javaMailSender;
 
     @Override
-    public boolean sendMail(List<Users> receiveList) {
+    public boolean sendMail(List<Users> receiveList, String redisCode) {
         MimeMessage message = javaMailSender.createMimeMessage();
 
         try {
             MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
             String imagesDirectory = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() +":" + httpServletRequest.getServerPort() + "/assets/images";
+            String passwordResetUrl = "https://jeffrey-oh.tistory.com/";
 
             for (Users users : receiveList) {
                 // 1. 메일 수신자 설정
@@ -37,7 +38,7 @@ public class MailServiceImpl implements MailService {
                 // 3. 메일 내용 설정
                 // HTML 적용됨
                 String content = """
-                    <!DOCTYPE html>
+                   <!DOCTYPE html>
                    <html lang="ko">
                    
                    <head>
@@ -56,8 +57,9 @@ public class MailServiceImpl implements MailService {
                                <b>{nickname}</b>님 안녕하세요.<br />
                                아래 버튼을 선택하여 비밀번호를 재설정해주세요.
                            </div>
-                           <div style="margin-top: 20px;">
-                               <button style="width: 200px; height: 50px; border-radius: 4px; background-color: #00CC8F; border-color: #FFF; border-width: 0px; font-size: 16px; color: #FFF;" type="button">비밀번호 재설정하기</button> </div>
+                           <a href="{password-reset-url}" target="_blank" style="text-decoration: unset; display: inline-block;">
+                               <div style="margin-top: 20px; width: 200px; height: 50px; border-radius: 4px; background-color: #00CC8F; border-color: #FFF; border-width: 0px; font-size: 16px; color: #FFF; display: block; text-align: center; line-height: 50px;">비밀번호 재설정하기</div>
+                           </a>
                            <div style="margin-top: 20px;">
                                <span style="color: #808080;">(비밀번호 재설정 링크는 1시간 동안 유효합니다.)</span>
                            </div>
@@ -75,6 +77,7 @@ public class MailServiceImpl implements MailService {
                     """;
                 content = content.replace("{images-directory}", imagesDirectory);
                 content = content.replace("{nickname}", users.getName());
+                content = content.replace("{password-reset-url}", passwordResetUrl);
                 messageHelper.setText(content,true);
 
                 // 4. 메일 전송

--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/util/RedisUtil.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/util/RedisUtil.java
@@ -28,4 +28,10 @@ public class RedisUtil {
     public CompletableFuture<Boolean> hasKey(String key) {
         return CompletableFuture.completedFuture(Boolean.TRUE.equals(redisTemplate.hasKey(key)));
     }
+
+    @Async
+    public CompletableFuture<Object> get(String key) {
+        return CompletableFuture.completedFuture(redisTemplate.opsForValue().get(key));
+    }
+
 }

--- a/app-api/src/main/java/com/ddd/chulsi/presentation/users/UsersController.java
+++ b/app-api/src/main/java/com/ddd/chulsi/presentation/users/UsersController.java
@@ -10,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping(value = "/users", name = "유저")
 @RequiredArgsConstructor
@@ -72,6 +74,23 @@ public class UsersController {
     ) {
         UsersCommand.PasswordFind passwordFind = passwordFindRequest.toCommand();
         usersFacade.passwordFind(passwordFind);
+        return BaseResponse.ofSuccess();
+    }
+
+    @PostMapping(value = "/password-link-alive", name = "비밀번호 재설정 링크 유효성 검사")
+    public BaseResponse<Boolean> passwordLinkAlive(
+        @RequestBody @Valid UsersDTO.PasswordLinkAliveRequest passwordLinkAliveRequest
+    ) {
+        UsersCommand.PasswordLinkAlive passwordLinkAlive = passwordLinkAliveRequest.toCommand();
+        return BaseResponse.ofSuccess(usersFacade.passwordLinkAlive(passwordLinkAlive));
+    }
+
+    @PutMapping(value = "/password-reset", name = "비밀번호 재설정")
+    public BaseResponse<Void> passwordReset(
+        @RequestBody @Valid UsersDTO.PasswordResetRequest passwordResetRequest
+    ) {
+        UsersCommand.PasswordReset passwordReset = passwordResetRequest.toCommand();
+        usersFacade.passwordReset(passwordReset);
         return BaseResponse.ofSuccess();
     }
 

--- a/app-api/src/main/java/com/ddd/chulsi/presentation/users/dto/UsersDTO.java
+++ b/app-api/src/main/java/com/ddd/chulsi/presentation/users/dto/UsersDTO.java
@@ -5,13 +5,18 @@ import com.ddd.chulsi.domainCore.model.users.UsersInfo;
 import com.ddd.chulsi.infrastructure.exception.BadRequestException;
 import com.ddd.chulsi.infrastructure.exception.message.ErrorMessage;
 import com.ddd.chulsi.infrastructure.util.BCryptUtils;
+import com.ddd.chulsi.infrastructure.util.StringUtil;
 import io.micrometer.common.util.StringUtils;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.commons.validator.routines.EmailValidator;
+import org.hibernate.validator.constraints.Length;
 
 import java.util.Objects;
+import java.util.UUID;
 
 public class UsersDTO {
 
@@ -41,14 +46,24 @@ public class UsersDTO {
         public Register {
             if (StringUtils.isBlank(nickname))
                 throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "nickname");
+            if (nickname.length() < 2 || nickname.length() > 10)
+                throw new BadRequestException("이름은 2자 이상, 10자 이하로 입력해주세요", "nickname");
+
             if (StringUtils.isBlank(email) || !EmailValidator.getInstance().isValid(email))
-                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "email");
+                throw new BadRequestException(ErrorMessage.EMAIL_VALIDATION_FAILED, "email");
+
             if (StringUtils.isBlank(password))
                 throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "password");
+            if (!StringUtil.isEnglishAndNumberAndSpecial(password, 8))
+                throw new BadRequestException(ErrorMessage.PASSWORD_VALIDATION_FAILED, "password");
+
             if (StringUtils.isBlank(passwordCheck))
                 throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "passwordCheck");
+            if (!StringUtil.isEnglishAndNumberAndSpecial(passwordCheck, 8))
+                throw new BadRequestException(ErrorMessage.PASSWORD_VALIDATION_FAILED, "passwordCheck");
+
             if (!Objects.deepEquals(password, passwordCheck))
-                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "password, passwordCheck");
+                throw new BadRequestException("입력하신 비밀번호가 일치하지 않습니다", "password, passwordCheck");
         }
         public UsersCommand.RegisterCommand toCommand() {
             return UsersCommand.RegisterCommand.nonState(nickname, email, BCryptUtils.hash(password));
@@ -61,9 +76,11 @@ public class UsersDTO {
     ) {
         public LoginRequest {
             if (StringUtils.isBlank(email) || !EmailValidator.getInstance().isValid(email))
-                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "email");
+                throw new BadRequestException(ErrorMessage.EMAIL_VALIDATION_FAILED, "email");
             if (StringUtils.isBlank(password))
                 throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "password");
+            if (!StringUtil.isEnglishAndNumberAndSpecial(password, 8))
+                throw new BadRequestException(ErrorMessage.PASSWORD_VALIDATION_FAILED, "password");
         }
         public UsersCommand.UsersLogin toCommand() {
             return UsersCommand.UsersLogin.nonState(email, BCryptUtils.hash(password));
@@ -79,6 +96,51 @@ public class UsersDTO {
         }
         public UsersCommand.PasswordFind toCommand() {
             return UsersCommand.PasswordFind.nonState(email);
+        }
+    }
+
+    public record PasswordResetRequest(
+        UUID usersId,
+        String password,
+        String passwordCheck
+    ) {
+        public PasswordResetRequest {
+            if (usersId == null)
+                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "usersId");
+
+            if (StringUtils.isBlank(password))
+                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "password");
+            if (!StringUtil.isEnglishAndNumberAndSpecial(password, 8))
+                throw new BadRequestException(ErrorMessage.PASSWORD_VALIDATION_FAILED, "password");
+
+            if (StringUtils.isBlank(passwordCheck))
+                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "passwordCheck");
+            if (!StringUtil.isEnglishAndNumberAndSpecial(passwordCheck, 8))
+                throw new BadRequestException(ErrorMessage.PASSWORD_VALIDATION_FAILED, "passwordCheck");
+
+            if (!Objects.deepEquals(password, passwordCheck))
+                throw new BadRequestException("입력하신 비밀번호가 일치하지 않습니다", "password, passwordCheck");
+        }
+
+        public UsersCommand.PasswordReset toCommand() {
+            return UsersCommand.PasswordReset.nonState(usersId, BCryptUtils.hash(password));
+        }
+    }
+
+    public record PasswordLinkAliveRequest(
+        UUID usersId,
+        String code
+    ) {
+        public PasswordLinkAliveRequest {
+            if (usersId == null)
+                throw new BadRequestException(ErrorMessage.EXPECTATION_FAILED_MSG_DEFAULT, "usersId");
+
+            if (StringUtils.isBlank(code))
+                throw new BadRequestException(ErrorMessage.FORBIDDEN);
+        }
+
+        public UsersCommand.PasswordLinkAlive toCommand() {
+            return UsersCommand.PasswordLinkAlive.nonState(usersId, code);
         }
     }
 }

--- a/app-api/src/test/java/com/ddd/chulsi/infrastructure/inMemory/users/UsersFactory.java
+++ b/app-api/src/test/java/com/ddd/chulsi/infrastructure/inMemory/users/UsersFactory.java
@@ -16,7 +16,7 @@ public class UsersFactory {
             .oauthId(2_384_324L)
             .oauthType(DefinedCode.C000200001)
             .email("email@email.com")
-            .password("비밀번호")
+            .password("qwer1234!")
             .name("이름")
             .refreshToken("refreshToken")
             .lastLoginAt(LocalDateTime.now())
@@ -35,7 +35,7 @@ public class UsersFactory {
     public static UsersDTO.LoginRequest givenLoginRequest() {
         return new UsersDTO.LoginRequest(
             "sikdorok@chulsi.com",
-            "비밀번호"
+            "qwer1234!"
         );
     }
 
@@ -43,8 +43,8 @@ public class UsersFactory {
         return new UsersDTO.Register(
             "닉네임",
             "sikdorok@chulsi.com",
-            "비밀번호",
-            "비밀번호"
+            "qwer1234!",
+            "qwer1234!"
         );
     }
 

--- a/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/users/UsersCommand.java
+++ b/domain-core/src/main/java/com/ddd/chulsi/domainCore/model/users/UsersCommand.java
@@ -51,4 +51,22 @@ public class UsersCommand {
             return new PasswordFind(email);
         }
     }
+
+    public record PasswordReset(
+        UUID usersId,
+        String password
+    ) {
+        public static PasswordReset nonState(UUID usersId, String password) {
+            return new PasswordReset(usersId, password);
+        }
+    }
+
+    public record PasswordLinkAlive(
+        UUID usersId,
+        String code
+    ) {
+        public static PasswordLinkAlive nonState(UUID usersId, String code) {
+            return new PasswordLinkAlive(usersId, code);
+        }
+    }
 }

--- a/system-core/src/main/java/com/ddd/chulsi/infrastructure/util/StringUtil.java
+++ b/system-core/src/main/java/com/ddd/chulsi/infrastructure/util/StringUtil.java
@@ -1,6 +1,7 @@
 package com.ddd.chulsi.infrastructure.util;
 
 import java.util.List;
+import java.util.Random;
 import java.util.regex.Pattern;
 
 public class StringUtil {
@@ -208,6 +209,16 @@ public class StringUtil {
         }
 
         return result;
+    }
+
+    public static String getRandomNumberString() {
+        // It will generate 6 digit random Number.
+        // from 0 to 999999
+        Random rnd = new Random();
+        int number = rnd.nextInt(999999);
+
+        // this will convert any number sequence into 6 character.
+        return String.format("%06d", number);
     }
 
 


### PR DESCRIPTION
- 유효성 조건 추가 작업
  - 로그인, 회원가입 등
- redis 관련 로직 추가
- 비밀번호 찾기 프로세스
  - 이메일 발송
    - 발송 전
      - redis 에 PASSWORD_LINK_ALIVE: + usersId 조합키 있는지 체크
      - 값이 있으면 삭제 및 랜덤코드 동일하지 않을 때 까지 무한반복해서 코드 생성
    - 발송 후
      - redis 에  PASSWORD_LINK_ALIVE: + usersId 조합으로 다시 설정
  - 이메일 본문에서 버튼 클릭
    - 다이나믹 링크 파라미터로 usersId, code 2개 달아서 전송
    - 비밀번호 재설정 페이지에서 API 통신
      - password-link-alive 통신하여 boolean 값 받기
      - password-reset 통신하여 비밀번호 재설정하기
      - 재설정 성공 시 redis 값 삭제