### PR TITLE
카카오 로그인 로직 수정

### DIFF
--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/oauth/OauthInfo.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/oauth/OauthInfo.java
@@ -1,6 +1,8 @@
 package com.ddd.chulsi.infrastructure.oauth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 public class OauthInfo {
 
@@ -39,7 +41,16 @@ public class OauthInfo {
     ) {
         public record KakaoAccount (
             @JsonProperty("profile")
-            KakaoProfile kakaoProfile
+            KakaoProfile kakaoProfile,
+
+            @JsonProperty("is_email_valid")
+            boolean isEmailValid,
+
+            @JsonProperty("is_email_verified")
+            boolean isEmailVerified,
+
+            @JsonProperty("email")
+            String email
         ) { }
 
         public record KakaoProfile (
@@ -47,4 +58,9 @@ public class OauthInfo {
             String nickname
         ) { }
     }
+
+    public record KakaoUserMeDTO (
+       String nickname,
+       String email
+    ) {}
 }

--- a/app-api/src/main/java/com/ddd/chulsi/infrastructure/oauth/OauthKakaoServiceImpl.java
+++ b/app-api/src/main/java/com/ddd/chulsi/infrastructure/oauth/OauthKakaoServiceImpl.java
@@ -105,7 +105,7 @@ public class OauthKakaoServiceImpl implements OauthKakaoService {
             httpHeaders.set("Authorization", accessToken.startsWith(JwtTokenUtil.PREFIX) ? accessToken : JwtTokenUtil.PREFIX + accessToken);
 
             MultiValueMap<String, Object> requestBody = new LinkedMultiValueMap<>();
-            requestBody.add("property_keys", "[\"kakao_account.profile\"]");
+            requestBody.add("property_keys", "[\"kakao_account.profile\", \"kakao_account.email\"]");
             HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(requestBody, httpHeaders);
 
             OauthInfo.KakaoUserMe response = restTemplate.postForObject(

--- a/app-api/src/main/java/com/ddd/chulsi/presentation/users/UsersController.java
+++ b/app-api/src/main/java/com/ddd/chulsi/presentation/users/UsersController.java
@@ -26,7 +26,7 @@ public class UsersController {
     }
 
     @PostMapping(value = "/kakao/login", name = "카카오 로그인")
-    public BaseResponse<UsersDTO.LoginResponse> kakaoLogin(
+    public BaseResponse<UsersDTO.KakaoLoginResponse> kakaoLogin(
         @RequestBody @Valid UsersDTO.OauthLoginRequest loginRequest,
         HttpServletResponse response
     ) {

--- a/app-api/src/main/java/com/ddd/chulsi/presentation/users/dto/UsersDTO.java
+++ b/app-api/src/main/java/com/ddd/chulsi/presentation/users/dto/UsersDTO.java
@@ -25,7 +25,15 @@ public class UsersDTO {
     }
 
     public record LoginResponse (
-        UsersInfo.UsersInfoLogin usersInfoLogin
+        boolean isRegistered,
+        UsersInfo.UsersInfoLogin usersInfo
+    ) {
+
+    }
+
+    public record KakaoLoginResponse<T> (
+        boolean isRegistered,
+        T usersInfo
     ) {
 
     }

--- a/app-api/src/test/java/com/ddd/chulsi/infrastructure/inMemory/users/UsersFactory.java
+++ b/app-api/src/test/java/com/ddd/chulsi/infrastructure/inMemory/users/UsersFactory.java
@@ -29,7 +29,13 @@ public class UsersFactory {
     public static UsersDTO.LoginResponse givenLoginResponse() {
         UsersInfo.UsersInfoLogin usersInfoLogin = new UsersInfo.UsersInfoLogin(givenUsers(), "oauth access token");
         usersInfoLogin.setAccessToken("access Token");
-        return new UsersDTO.LoginResponse(usersInfoLogin);
+        return new UsersDTO.LoginResponse(true, usersInfoLogin);
+    }
+
+    public static UsersDTO.KakaoLoginResponse givenKakaoLoginResponse() {
+        UsersInfo.UsersInfoLogin usersInfoLogin = new UsersInfo.UsersInfoLogin(givenUsers(), "oauth access token");
+        usersInfoLogin.setAccessToken("access Token");
+        return new UsersDTO.KakaoLoginResponse(true, usersInfoLogin);
     }
 
     public static UsersDTO.LoginRequest givenLoginRequest() {

--- a/app-api/src/test/java/com/ddd/chulsi/presentation/users/UsersControllerTest.java
+++ b/app-api/src/test/java/com/ddd/chulsi/presentation/users/UsersControllerTest.java
@@ -49,7 +49,7 @@ class UsersControllerTest extends ControllerTest {
     @Test
     void 카카오_로그인() throws Exception {
 
-        given(usersFacade.kakaoLogin(any(UsersCommand.LoginCommand.class), any(HttpServletResponse.class))).willReturn(givenLoginResponse());
+        given(usersFacade.kakaoLogin(any(UsersCommand.LoginCommand.class), any(HttpServletResponse.class))).willReturn(givenKakaoLoginResponse());
 
         UsersDTO.OauthLoginRequest request = new UsersDTO.OauthLoginRequest("authorizationCode");
 
@@ -72,10 +72,11 @@ class UsersControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 데이터"),
-                    fieldWithPath("data.usersInfoLogin").type(JsonFieldType.OBJECT).description("유저 정보"),
-                    fieldWithPath("data.usersInfoLogin.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
-                    fieldWithPath("data.usersInfoLogin.accessToken").type(JsonFieldType.STRING).description("access token"),
-                    fieldWithPath("data.usersInfoLogin.lastLoginAt").type(JsonFieldType.STRING).description("마지막 로그인 일시")
+                    fieldWithPath("data.isRegistered").type(JsonFieldType.BOOLEAN).description("회원가입 유무"),
+                    fieldWithPath("data.usersInfo").type(JsonFieldType.OBJECT).description("유저 정보"),
+                    fieldWithPath("data.usersInfo.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
+                    fieldWithPath("data.usersInfo.accessToken").type(JsonFieldType.STRING).description("access token"),
+                    fieldWithPath("data.usersInfo.lastLoginAt").type(JsonFieldType.STRING).description("마지막 로그인 일시")
                 )
             ));
 
@@ -136,10 +137,11 @@ class UsersControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 데이터"),
-                    fieldWithPath("data.usersInfoLogin").type(JsonFieldType.OBJECT).description("유저 로그인 정보"),
-                    fieldWithPath("data.usersInfoLogin.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
-                    fieldWithPath("data.usersInfoLogin.accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
-                    fieldWithPath("data.usersInfoLogin.lastLoginAt").type(JsonFieldType.STRING).attributes(dateFormatFull()).description("마지막 로그인 일시").optional()
+                    fieldWithPath("data.isRegistered").type(JsonFieldType.BOOLEAN).description("회원가입 유무"),
+                    fieldWithPath("data.usersInfo").type(JsonFieldType.OBJECT).description("유저 로그인 정보"),
+                    fieldWithPath("data.usersInfo.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
+                    fieldWithPath("data.usersInfo.accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
+                    fieldWithPath("data.usersInfo.lastLoginAt").type(JsonFieldType.STRING).attributes(dateFormatFull()).description("마지막 로그인 일시").optional()
                 )
             ));
 
@@ -172,10 +174,11 @@ class UsersControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 데이터"),
-                    fieldWithPath("data.usersInfoLogin").type(JsonFieldType.OBJECT).description("유저 로그인 정보"),
-                    fieldWithPath("data.usersInfoLogin.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
-                    fieldWithPath("data.usersInfoLogin.accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
-                    fieldWithPath("data.usersInfoLogin.lastLoginAt").type(JsonFieldType.STRING).attributes(dateFormatFull()).description("마지막 로그인 일시").optional()
+                    fieldWithPath("data.isRegistered").type(JsonFieldType.BOOLEAN).description("회원가입 유무"),
+                    fieldWithPath("data.usersInfo").type(JsonFieldType.OBJECT).description("유저 로그인 정보"),
+                    fieldWithPath("data.usersInfo.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
+                    fieldWithPath("data.usersInfo.accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
+                    fieldWithPath("data.usersInfo.lastLoginAt").type(JsonFieldType.STRING).attributes(dateFormatFull()).description("마지막 로그인 일시").optional()
                 )
             ));
 
@@ -200,10 +203,11 @@ class UsersControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 데이터"),
-                    fieldWithPath("data.usersInfoLogin").type(JsonFieldType.OBJECT).description("유저 로그인 정보"),
-                    fieldWithPath("data.usersInfoLogin.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
-                    fieldWithPath("data.usersInfoLogin.accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
-                    fieldWithPath("data.usersInfoLogin.lastLoginAt").type(JsonFieldType.STRING).attributes(dateFormatFull()).description("마지막 로그인 일시").optional()
+                    fieldWithPath("data.isRegistered").type(JsonFieldType.BOOLEAN).description("회원가입 유무"),
+                    fieldWithPath("data.usersInfo").type(JsonFieldType.OBJECT).description("유저 로그인 정보"),
+                    fieldWithPath("data.usersInfo.usersId").type(JsonFieldType.STRING).description("유저 고유번호"),
+                    fieldWithPath("data.usersInfo.accessToken").type(JsonFieldType.STRING).description("JWT Access Token"),
+                    fieldWithPath("data.usersInfo.lastLoginAt").type(JsonFieldType.STRING).attributes(dateFormatFull()).description("마지막 로그인 일시").optional()
                 )
             ));
 


### PR DESCRIPTION
- 로그인 Response 분기처리
- 개인인증으로 비즈앱 전환 완료 및 이메일 동의 필수 항목 처리
  - 이메일 없거나 미인증의 경우 사용자로 부터 받을 수 있게 별도 체크 설정함
  - 이메일 필수항목으로 사용자에게 동의 받고 가져오게함
- `isRegistered` false 경우 response 다르게 제공 
  - `nickname` , `email` 
  - 이메일 유효성 검사 (카카오 기준) 및 중복검사 (식도록) 통과 한 경우 그대로 사용, 그 외 null 로 Response 제공